### PR TITLE
feat(filter): filter export library files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+# 0.1.0
+
+## Feature
+
+- Filter export library files
+
 # 0.0.1
 
 - Initial release of the package.

--- a/lib/src/commands/scan_command.dart
+++ b/lib/src/commands/scan_command.dart
@@ -1,6 +1,6 @@
 import 'package:args/command_runner.dart';
 import 'package:discover/src/converters/lcov_converter.dart';
-import 'package:discover/src/extensions/file_system_entity_extension.dart';
+import 'package:discover/src/extensions/extensions.dart';
 import 'package:discover/src/system/system_runner.dart';
 import 'package:file/file.dart';
 import 'package:mason_logger/mason_logger.dart';
@@ -52,9 +52,7 @@ class ScanCommand extends Command<int> {
       _logger.err('lib directory does not exist');
       return ExitCode.noInput.code;
     }
-    final dartFiles = libDirectory
-        .listSync(recursive: true)
-        .where((entity) => entity.path.endsWith('.dart'));
+    final dartFiles = listDartFiles(libDirectory);
 
     if (dartFiles.isEmpty) {
       _logger.err('No Dart files found in ${libDirectory.path}');
@@ -104,6 +102,15 @@ class ScanCommand extends Command<int> {
     }
 
     return ExitCode.success.code;
+  }
+
+  Iterable<File> listDartFiles(Directory libDirectory) {
+    final dartFiles = libDirectory
+        .listSync(recursive: true)
+        .where((entity) => entity.path.endsWith('.dart'))
+        .map((entity) => entity as File)
+        .where((file) => file.isNotExportLibrary());
+    return dartFiles;
   }
 
   List<String> _readSourceFilesFromCoverage(File coverageFile) {

--- a/lib/src/extensions/extensions.dart
+++ b/lib/src/extensions/extensions.dart
@@ -1,0 +1,2 @@
+export 'file_extension.dart';
+export 'file_system_entity_extension.dart';

--- a/lib/src/extensions/file_extension.dart
+++ b/lib/src/extensions/file_extension.dart
@@ -1,0 +1,34 @@
+import 'package:file/file.dart';
+
+extension FileExtension on File {
+  List<String> readAsCodeLinesSync() {
+    final lines = readAsLinesSync();
+    return lines
+        .map((line) => line.trim())
+        .where((line) => line.isNotEmpty && !line.startsWith('//'))
+        .toList();
+  }
+
+  bool isNotEmpty() {
+    return existsSync() &&
+        readAsCodeLinesSync()
+            .where((line) => line.trim().isNotEmpty)
+            .isNotEmpty;
+  }
+
+  bool isExportLibrary() {
+    return isNotEmpty() &&
+        readAsCodeLinesSync()
+            .every((line) => _isExport(line) || _isLibrary(line));
+  }
+
+  bool isNotExportLibrary() => !isExportLibrary();
+
+  bool _isExport(String line) {
+    return line.startsWith('export');
+  }
+
+  bool _isLibrary(String line) {
+    return line.startsWith('library');
+  }
+}

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '0.0.1';
+const packageVersion = '0.1.0';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: discover
 description: Discover your real coverage with Dart and Flutter.
-version: 0.0.1
+version: 0.1.0
 repository: https://github.com/PiotrFLEURY/discover
 
 environment:

--- a/test/src/extensions/file_extension_test.dart
+++ b/test/src/extensions/file_extension_test.dart
@@ -1,0 +1,234 @@
+import 'package:discover/src/extensions/extensions.dart';
+import 'package:file/memory.dart';
+import 'package:test/expect.dart';
+import 'package:test/scaffolding.dart';
+
+void main() {
+  final fileSystem = MemoryFileSystem();
+
+  group('readAsCodeLinesSync', () {
+    test('empty file should return empty list', () {
+      // GIVEN
+      final file = fileSystem.file('test.dart')..writeAsStringSync('');
+
+      // WHEN
+      final codeLines = file.readAsCodeLinesSync();
+
+      // THEN
+      expect(codeLines, isEmpty);
+    });
+    test('empty lines should be ignored', () {
+      // GIVEN
+      final file = fileSystem.file('test.dart')
+        ..writeAsStringSync(
+          '''
+        
+        ''',
+        );
+
+      // WHEN
+      final codeLines = file.readAsCodeLinesSync();
+
+      // THEN
+      expect(codeLines, isEmpty);
+    });
+    test('comments should be ignored', () {
+      // GIVEN
+      final file = fileSystem.file('test.dart')
+        ..writeAsStringSync(
+          '''
+        // This is a comment
+        // Another comment
+        // Yet another comment
+        ''',
+        );
+
+      // WHEN
+      final codeLines = file.readAsCodeLinesSync();
+
+      // THEN
+      expect(codeLines, isEmpty);
+    });
+    test('code should be returned', () {
+      // GIVEN
+      final file = fileSystem.file('test.dart')
+        ..writeAsStringSync(
+          '''
+        void main() {
+          print('Hello, world!');
+        }
+        ''',
+        );
+
+      // WHEN
+      final codeLines = file.readAsCodeLinesSync();
+
+      // THEN
+      expect(codeLines, isNotEmpty);
+      expect(codeLines.length, 3);
+      expect(codeLines[0], 'void main() {');
+      expect(codeLines[1], "print('Hello, world!');");
+      expect(codeLines[2], '}');
+    });
+    test('complex example', () {
+      // GIVEN
+      final file = fileSystem.file('test.dart')
+        ..writeAsStringSync(
+          '''
+          
+        /// This is a documentation comment
+        void main() {
+        
+          // This is a comment
+          print('Hello, world!');
+          
+        }
+        
+        ''',
+        );
+
+      // WHEN
+      final codeLines = file.readAsCodeLinesSync();
+
+      // THEN
+      expect(codeLines, isNotEmpty);
+      expect(codeLines.length, 3);
+      expect(codeLines[0], 'void main() {');
+      expect(codeLines[1], "print('Hello, world!');");
+      expect(codeLines[2], '}');
+    });
+  });
+  group('isNotEmpty', () {
+    test('empty file should return false', () {
+      // GIVEN
+      final file = fileSystem.file('test.dart')..writeAsStringSync('');
+
+      // WHEN
+      final isNotEmpty = file.isNotEmpty();
+
+      // THEN
+      expect(isNotEmpty, isFalse);
+    });
+    test('file with only empty lines should return false', () {
+      // GIVEN
+      final file = fileSystem.file('test.dart')
+        ..writeAsStringSync(
+          '''
+        
+        ''',
+        );
+
+      // WHEN
+      final isNotEmpty = file.isNotEmpty();
+
+      // THEN
+      expect(isNotEmpty, isFalse);
+    });
+    test('file with only comments should return false', () {
+      // GIVEN
+      final file = fileSystem.file('test.dart')
+        ..writeAsStringSync(
+          '''
+        // This is a comment
+        // Another comment
+        ''',
+        );
+
+      // WHEN
+      final isNotEmpty = file.isNotEmpty();
+
+      // THEN
+      expect(isNotEmpty, isFalse);
+    });
+  });
+  group('isExportLibrary', () {
+    test('empty file should return false', () {
+      // GIVEN
+      final file = fileSystem.file('test.dart')..writeAsStringSync('');
+
+      // WHEN
+      final isExportLibrary = file.isExportLibrary();
+
+      // THEN
+      expect(isExportLibrary, isFalse);
+    });
+    test('file with only empty lines should return false', () {
+      // GIVEN
+      final file = fileSystem.file('test.dart')
+        ..writeAsStringSync(
+          '''
+        
+        ''',
+        );
+
+      // WHEN
+      final isExportLibrary = file.isExportLibrary();
+
+      // THEN
+      expect(isExportLibrary, isFalse);
+    });
+    test('file with only comments should return false', () {
+      // GIVEN
+      final file = fileSystem.file('test.dart')
+        ..writeAsStringSync(
+          '''
+        // This is a comment
+        // Another comment
+        ''',
+        );
+
+      // WHEN
+      final isExportLibrary = file.isExportLibrary();
+
+      // THEN
+      expect(isExportLibrary, isFalse);
+    });
+    test('file with library declaration should return true', () {
+      // GIVEN
+      final file = fileSystem.file('test.dart')
+        ..writeAsStringSync(
+          '''
+        library my_library;
+        ''',
+        );
+
+      // WHEN
+      final isExportLibrary = file.isExportLibrary();
+
+      // THEN
+      expect(isExportLibrary, isTrue);
+    });
+    test('file with export declaration should return true', () {
+      // GIVEN
+      final file = fileSystem.file('test.dart')
+        ..writeAsStringSync(
+          '''
+        export 'my_library.dart';
+        ''',
+        );
+
+      // WHEN
+      final isExportLibrary = file.isExportLibrary();
+
+      // THEN
+      expect(isExportLibrary, isTrue);
+    });
+    test('file with both library and export declarations should return true',
+        () {
+      // GIVEN
+      final file = fileSystem.file('test.dart')
+        ..writeAsStringSync(
+          '''
+        library my_library;
+        export 'my_library.dart';
+        ''',
+        );
+
+      // WHEN
+      final isExportLibrary = file.isExportLibrary();
+
+      // THEN
+      expect(isExportLibrary, isTrue);
+    });
+  });
+}


### PR DESCRIPTION
This pull request includes multiple changes aimed at adding a new feature to filter export library files, updating the package version, and enhancing the test coverage. The most important changes include updating the `ScanCommand` class to filter Dart files, adding new file extensions, and updating the tests to ensure the new functionality works correctly.

### Feature Additions and Updates:

* [`lib/src/commands/scan_command.dart`](diffhunk://#diff-48dee9b74902b99434936455455f2d34a72f2dfdf837512a6f6fb610ce47a268L55-R55): Updated the `ScanCommand` class to filter Dart files by adding a new method `listDartFiles` that excludes export library files. [[1]](diffhunk://#diff-48dee9b74902b99434936455455f2d34a72f2dfdf837512a6f6fb610ce47a268L55-R55) [[2]](diffhunk://#diff-48dee9b74902b99434936455455f2d34a72f2dfdf837512a6f6fb610ce47a268R107-R115)
* [`lib/src/extensions/file_extension.dart`](diffhunk://#diff-8e8f41a947504b3b3c4b38b3e3c2bb0e1a08decf8ec0240bce487622590a1de5R1-R34): Added new extension methods to the `File` class to determine if a file is an export library and to read code lines, ignoring comments and empty lines.
* [`lib/src/extensions/extensions.dart`](diffhunk://#diff-2b16857bf62effbb9d643290f59896b11963292f56728e5b78facc9060c561a8R1-R2): Exported the new file extension methods.

### Version Updates:

* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR3-R8): Updated the changelog to reflect the new version `0.1.0` and the addition of the feature to filter export library files.
* [`lib/src/version.dart`](diffhunk://#diff-389218715db21eae82edc77d255cd5fdcbab37f3a3d482b84aa82c75a9f9d52eL2-R2): Updated the package version to `0.1.0`.
* [`pubspec.yaml`](diffhunk://#diff-8b7e9df87668ffa6a04b32e1769a33434999e54ae081c52e5d943c541d4c0d25L3-R3): Updated the package version to `0.1.0`.

### Test Enhancements:

* [`test/src/commands/scan_command_test.dart`](diffhunk://#diff-498622884b1c2039cf96645e73b6790e78dab8f25b8bb0b65395568e992a3266R231-R274): Added new tests to verify that the `scan` command ignores export library files.
* [`test/src/extensions/file_extension_test.dart`](diffhunk://#diff-5f2075844fa5331d59162fd20942e40acd4d1e6d060a39fa1bb3267bfc69d4dbR1-R236): Added comprehensive tests for the new file extension methods to ensure they work as expected.