### PR TITLE
fix(lcov): fix lcov file name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Filter export library files
 
+## Fix
+
+- Fix lcov file name
+
 # 0.0.1
 
 - Initial release of the package.

--- a/lib/src/commands/scan_command.dart
+++ b/lib/src/commands/scan_command.dart
@@ -133,7 +133,7 @@ class ScanCommand extends Command<int> {
     _logger.info(
       'Generating lcov file for Dart files not listed in coverage file.',
     );
-    final lcovFile = coverageDirectory.childFile('discovery-lcov.info');
+    final lcovFile = coverageDirectory.childFile('discover-lcov.info');
     _lcovConverter.writeLcovFile(dartFilesNotInCoverage, lcovFile);
   }
 


### PR DESCRIPTION
This pull request includes a fix for the lcov file name in both the documentation and the codebase.

Fixes:

* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR9-R12): Added a fix entry to document the lcov file name correction.
* [`lib/src/commands/scan_command.dart`](diffhunk://#diff-48dee9b74902b99434936455455f2d34a72f2dfdf837512a6f6fb610ce47a268L136-R136): Corrected the lcov file name from `discovery-lcov.info` to `discover-lcov.info`.