### PR TITLE
fix(documentation): remove angle brackets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ## Fix
 
 - Fix lcov file name
+- Fix documentation angle brackets
 
 # 0.0.1
 

--- a/lib/src/converters/lcov_converter.dart
+++ b/lib/src/converters/lcov_converter.dart
@@ -8,8 +8,8 @@ import 'package:mason_logger/mason_logger.dart';
 ///
 /// SF:path/to/file.dart
 /// DA:1,0
-/// LF:<total lines>
-/// LH:<lines hit>
+/// LF:[total lines]
+/// LH:[lines hit]
 /// end_of_record
 ///
 class LcovConverter {


### PR DESCRIPTION
This pull request includes minor fixes to the documentation in the `CHANGELOG.md` file and the `LcovConverter` class.

Documentation fixes:

* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR12): Added a fix for documentation angle brackets.
* [`lib/src/converters/lcov_converter.dart`](diffhunk://#diff-2904f6d9d7a60becd33c23342a95b8fd2978dfc555f26b7ea3855457a9ae608bL11-R12): Updated the angle brackets to square brackets in the documentation comments for `LF` and `LH`.