### PR TITLE
chore(publish): create publication CI

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,14 @@
+name: Publish to pub.dev
+
+on:
+  push:
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+*'
+
+jobs:
+  publish:
+    permissions:
+      id-token: write # Required for authentication using OIDC
+    uses: dart-lang/setup-dart/.github/workflows/publish.yml@v1
+    # with:
+    #   working-directory: path/to/package/within/repository


### PR DESCRIPTION
This pull request adds a new GitHub Actions workflow for publishing to pub.dev. The most important change is the creation of the `publish.yaml` file, which configures the workflow to trigger on tag pushes and uses the `dart-lang/setup-dart` action for the publishing process.

* [`.github/workflows/publish.yaml`](diffhunk://#diff-e81e13daadd1745de51d8b8d85fce1fcd9be355732b64d60a6b56e18c28388caR1-R14): Created a new workflow file to publish to pub.dev on tag pushes, including permissions for OIDC authentication and using the `dart-lang/setup-dart` action.