### PR TITLE
feat(ignore): ignore code not deserved to be covered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+# 0.3.0
+
+## Feature
+
+- ignore lines not supposed to be covered
+
 # 0.2.0
 
 ## Feature

--- a/lib/src/commands/scan_command.dart
+++ b/lib/src/commands/scan_command.dart
@@ -158,7 +158,7 @@ class ScanCommand extends Command<int> {
 
   void generateLcovFile(
     Directory coverageDirectory,
-    List<FileSystemEntity> dartFilesNotInCoverage,
+    List<File> dartFilesNotInCoverage,
   ) {
     _logger.info(
       'Generating lcov file for Dart files not listed in coverage file.',

--- a/lib/src/extensions/file_extension.dart
+++ b/lib/src/extensions/file_extension.dart
@@ -1,34 +1,34 @@
+import 'package:discover/src/models/code_line.dart';
 import 'package:file/file.dart';
 
 extension FileExtension on File {
-  List<String> readAsCodeLinesSync() {
+  List<CodeLine> readAsCodeLinesSync() {
     final lines = readAsLinesSync();
     return lines
-        .map((line) => line.trim())
-        .where((line) => line.isNotEmpty && !line.startsWith('//'))
+        .asMap()
+        .entries
+        .map(
+          (entry) => CodeLine(
+            code: entry.value,
+            lineNumber: entry.key + 1,
+          ),
+        )
         .toList();
   }
 
   bool isNotEmpty() {
     return existsSync() &&
         readAsCodeLinesSync()
-            .where((line) => line.trim().isNotEmpty)
+            .where((line) => line.isNotEmpty && !line.isComment)
             .isNotEmpty;
   }
 
   bool isExportLibrary() {
     return isNotEmpty() &&
         readAsCodeLinesSync()
-            .every((line) => _isExport(line) || _isLibrary(line));
+            .where((line) => line.isNotEmpty)
+            .every((line) => line.isExport || line.isLibrary);
   }
 
   bool isNotExportLibrary() => !isExportLibrary();
-
-  bool _isExport(String line) {
-    return line.startsWith('export');
-  }
-
-  bool _isLibrary(String line) {
-    return line.startsWith('library');
-  }
 }

--- a/lib/src/models/code_line.dart
+++ b/lib/src/models/code_line.dart
@@ -1,0 +1,24 @@
+///
+/// Represents a line of code in a Dart file.
+///
+class CodeLine {
+  const CodeLine({
+    required this.code,
+    required this.lineNumber,
+  });
+
+  final String code;
+  final int lineNumber;
+
+  String trim() => code.trim();
+
+  bool get isEmpty => trim().isEmpty;
+
+  bool get isNotEmpty => trim().isNotEmpty;
+
+  bool get isExport => trim().startsWith('export');
+
+  bool get isLibrary => trim().startsWith('library');
+
+  bool get isComment => trim().startsWith('//');
+}

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '0.2.0';
+const packageVersion = '0.3.0';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: discover
 description: Discover your real coverage with Flutter.
-version: 0.2.0
+version: 0.3.0
 repository: https://github.com/PiotrFLEURY/discover
 
 environment:

--- a/test/src/extensions/file_extension_test.dart
+++ b/test/src/extensions/file_extension_test.dart
@@ -17,7 +17,7 @@ void main() {
       // THEN
       expect(codeLines, isEmpty);
     });
-    test('empty lines should be ignored', () {
+    test('empty lines should be identified', () {
       // GIVEN
       final file = fileSystem.file('test.dart')
         ..writeAsStringSync(
@@ -30,34 +30,38 @@ void main() {
       final codeLines = file.readAsCodeLinesSync();
 
       // THEN
-      expect(codeLines, isEmpty);
+      expect(codeLines, isNotEmpty);
+      expect(codeLines[0].isEmpty, true);
     });
-    test('comments should be ignored', () {
+    test('comments should be identified', () {
       // GIVEN
       final file = fileSystem.file('test.dart')
         ..writeAsStringSync(
           '''
-        // This is a comment
-        // Another comment
-        // Yet another comment
-        ''',
+// This is a comment
+// Another comment
+// Yet another comment
+''',
         );
 
       // WHEN
       final codeLines = file.readAsCodeLinesSync();
 
       // THEN
-      expect(codeLines, isEmpty);
+      expect(codeLines, isNotEmpty);
+      expect(codeLines[0].isComment, true);
+      expect(codeLines[1].isComment, true);
+      expect(codeLines[2].isComment, true);
     });
     test('code should be returned', () {
       // GIVEN
       final file = fileSystem.file('test.dart')
         ..writeAsStringSync(
           '''
-        void main() {
-          print('Hello, world!');
-        }
-        ''',
+void main() {
+  print('Hello, world!');
+}
+''',
         );
 
       // WHEN
@@ -66,25 +70,25 @@ void main() {
       // THEN
       expect(codeLines, isNotEmpty);
       expect(codeLines.length, 3);
-      expect(codeLines[0], 'void main() {');
-      expect(codeLines[1], "print('Hello, world!');");
-      expect(codeLines[2], '}');
+      expect(codeLines[0].code, 'void main() {');
+      expect(codeLines[1].trim(), "print('Hello, world!');");
+      expect(codeLines[2].code, '}');
     });
     test('complex example', () {
       // GIVEN
       final file = fileSystem.file('test.dart')
         ..writeAsStringSync(
           '''
-          
-        /// This is a documentation comment
-        void main() {
-        
-          // This is a comment
-          print('Hello, world!');
-          
-        }
-        
-        ''',
+
+/// This is a documentation comment
+void main() {
+
+  // This is a comment
+  print('Hello, world!');
+
+}
+
+''',
         );
 
       // WHEN
@@ -92,10 +96,16 @@ void main() {
 
       // THEN
       expect(codeLines, isNotEmpty);
-      expect(codeLines.length, 3);
-      expect(codeLines[0], 'void main() {');
-      expect(codeLines[1], "print('Hello, world!');");
-      expect(codeLines[2], '}');
+      expect(codeLines.length, 9);
+      expect(codeLines[0].isEmpty, true);
+      expect(codeLines[1].isComment, true);
+      expect(codeLines[2].code, 'void main() {');
+      expect(codeLines[3].isEmpty, true);
+      expect(codeLines[4].isComment, true);
+      expect(codeLines[5].trim(), "print('Hello, world!');");
+      expect(codeLines[6].isEmpty, true);
+      expect(codeLines[7].code, '}');
+      expect(codeLines[8].isEmpty, true);
     });
   });
   group('isNotEmpty', () {


### PR DESCRIPTION
This pull request includes several changes to the codebase to improve the handling of Dart code coverage. The key changes involve updating the `LcovConverter` class to filter out lines that should be ignored in coverage reports, introducing a new `CodeLine` model, and updating related tests.

### Improvements to `LcovConverter`:

* Added regex patterns to identify lines that should be ignored in coverage reports, such as imports, comments, and class declarations (`lib/src/converters/lcov_converter.dart`). [[1]](diffhunk://#diff-2904f6d9d7a60becd33c23342a95b8fd2978dfc555f26b7ea3855457a9ae608bL1-R17) [[2]](diffhunk://#diff-2904f6d9d7a60becd33c23342a95b8fd2978dfc555f26b7ea3855457a9ae608bR33-R76) [[3]](diffhunk://#diff-2904f6d9d7a60becd33c23342a95b8fd2978dfc555f26b7ea3855457a9ae608bL64-R105) [[4]](diffhunk://#diff-2904f6d9d7a60becd33c23342a95b8fd2978dfc555f26b7ea3855457a9ae608bR118-R133)
* Updated the `writeLcovFile` method to use the new `CodeLine` model and filter ignored lines (`lib/src/converters/lcov_converter.dart`).

### New `CodeLine` model:

* Introduced the `CodeLine` class to represent a line of code with its content and line number (`lib/src/models/code_line.dart`).

### Changes to `FileExtension`:

* Updated the `FileExtension` to use `CodeLine` and added methods to identify empty lines and comments (`lib/src/extensions/file_extension.dart`).

### Tests:

* Added tests for the new filtering functionality in `LcovConverter` (`test/src/converters/lcov_converter_test.dart`).
* Updated existing tests to work with the `CodeLine` model and verify the correct identification of empty lines and comments (`test/src/extensions/file_extension_test.dart`). [[1]](diffhunk://#diff-5f2075844fa5331d59162fd20942e40acd4d1e6d060a39fa1bb3267bfc69d4dbL20-R20) [[2]](diffhunk://#diff-5f2075844fa5331d59162fd20942e40acd4d1e6d060a39fa1bb3267bfc69d4dbL33-R36) [[3]](diffhunk://#diff-5f2075844fa5331d59162fd20942e40acd4d1e6d060a39fa1bb3267bfc69d4dbL50-R54) [[4]](diffhunk://#diff-5f2075844fa5331d59162fd20942e40acd4d1e6d060a39fa1bb3267bfc69d4dbL69-R75) [[5]](diffhunk://#diff-5f2075844fa5331d59162fd20942e40acd4d1e6d060a39fa1bb3267bfc69d4dbL95-R108)

### Miscellaneous:

* Updated the package version to `0.3.0` in `pubspec.yaml` and `lib/src/version.dart` (`pubspec.yaml`, `lib/src/version.dart`). [[1]](diffhunk://#diff-8b7e9df87668ffa6a04b32e1769a33434999e54ae081c52e5d943c541d4c0d25L3-R3) [[2]](diffhunk://#diff-389218715db21eae82edc77d255cd5fdcbab37f3a3d482b84aa82c75a9f9d52eL2-R2)
* Added a new entry to the `CHANGELOG.md` to reflect the changes in version `0.3.0` (`CHANGELOG.md`).