### PR TITLE
docs(discoverignore): document discoverignore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 # 0.3.0
 
+## Doc
+
+- Document `.discoverignore` file
+
 ## Feature
 
 - ignore lines not supposed to be covered

--- a/README.md
+++ b/README.md
@@ -33,18 +33,47 @@ dart pub global activate --source=path <path to this package>
 
 ## Usage
 
+### Perform coverage scan
+
 ```sh
 # Scan command
 $ discover scan
 
 # Scan command option
 $ discover scan --path <dart_project_path>
+```
 
+### Tooling commands
+
+```sh
 # Show CLI version
 $ discover --version
 
 # Show usage help
 $ discover --help
+```
+
+### Ignore files
+
+You can ignore files by creating a `.discoverignore` file in the root of your project.
+
+```
+|-- android
+|-- ios
+|-- lib
+|-- linux
+|-- macos
+|-- test
+|-- windows
+|-- .discoverignore
+```
+
+Sample `.discoverignore` file:
+
+```
+lib/**/*.g.dart
+lib/**/*.freezed.dart
+lib/view/**/*.dart
 ```
 
 ## Running Tests with coverage 🧪

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: discover
-description: Discover your real coverage with Flutter.
+description: Discover your real coverage with Flutter including not tested Dart files.
 version: 0.3.0
 repository: https://github.com/PiotrFLEURY/discover
 


### PR DESCRIPTION
This pull request includes documentation updates to the `CHANGELOG.md` and `README.md` files, as well as a minor description update in the `pubspec.yaml` file. The most important changes are:

Documentation updates:

* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR5-R8): Added a new section to document the `.discoverignore` file.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R36-R78): Added sections to explain how to perform a coverage scan, tooling commands, and how to use the `.discoverignore` file to ignore specific files.

Minor description update:

* [`pubspec.yaml`](diffhunk://#diff-8b7e9df87668ffa6a04b32e1769a33434999e54ae081c52e5d943c541d4c0d25L2-R2): Updated the package description to include information about discovering coverage for not tested Dart files.