### PR TITLE
fix(15): log HTML report link instead of open it fix #15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+# 0.3.1
+
+## Fix
+
+- Replace HTML report opening by logs with link
+
 # 0.3.0
 
 ## Doc

--- a/lib/src/commands/scan_command.dart
+++ b/lib/src/commands/scan_command.dart
@@ -47,7 +47,7 @@ class ScanCommand extends Command<int> {
     final path = argResults?['path'] as String;
     final projectDirectory = path == '.'
         ? _fileSystem.currentDirectory
-        : _fileSystem.directory(path);
+        : _fileSystem.currentDirectory.childDirectory(path);
     final libDirectory = projectDirectory.childDirectory('lib');
     if (!libDirectory.existsSync()) {
       _logger.err('lib directory does not exist');
@@ -170,8 +170,14 @@ class ScanCommand extends Command<int> {
   }
 
   void generateHtmlReport(String projectPath) {
-    _systemRunner
-      ..runGenHTML(projectPath)
-      ..runOpenHtmlReport(projectPath);
+    _systemRunner.runGenHTML(projectPath);
+    final fullPath = '$projectPath/coverage/html/index.html';
+    final reportLink = link(
+      message: fullPath,
+      uri: Uri.parse(
+        'file://$fullPath',
+      ),
+    );
+    _logger.success('HTML report generated at $reportLink');
   }
 }

--- a/lib/src/system/system_runner.dart
+++ b/lib/src/system/system_runner.dart
@@ -44,20 +44,4 @@ class SystemRunner {
       throw Exception('Failed to run genhtml: ${process.stderr}');
     }
   }
-
-  void runOpenHtmlReport(
-    String projectPath,
-  ) {
-    final process = Process.runSync(
-      'open',
-      [
-        'coverage/html/index.html',
-      ],
-      workingDirectory: projectPath,
-    );
-
-    if (process.exitCode != 0) {
-      throw Exception('Failed to open HTML report: ${process.stderr}');
-    }
-  }
 }

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '0.3.0';
+const packageVersion = '0.3.1';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: discover
 description: Discover your real coverage with Flutter including not tested Dart files.
-version: 0.3.0
+version: 0.3.1
 repository: https://github.com/PiotrFLEURY/discover
 
 environment:

--- a/test/src/commands/scan_command_test.dart
+++ b/test/src/commands/scan_command_test.dart
@@ -224,9 +224,6 @@ end_of_record
       verify(
         () => systemRunner.runGenHTML(currentDirectory.path),
       ).called(1);
-      verify(
-        () => systemRunner.runOpenHtmlReport(currentDirectory.path),
-      ).called(1);
     });
 
     test('scan should ignore export library files', () async {
@@ -270,7 +267,6 @@ end_of_record
 
       verifyNever(() => lcovConverter.writeLcovFile(any(), any()));
       verifyNever(() => systemRunner.runGenHTML(currentDirectory.path));
-      verifyNever(() => systemRunner.runOpenHtmlReport(currentDirectory.path));
     });
 
     test('scan no coverage', () async {


### PR DESCRIPTION
This pull request includes several changes aimed at improving the HTML report generation process and updating the version of the package. The most important changes include replacing the HTML report opening with logs containing a link, updating the version in multiple files, and modifying the `ScanCommand` class to reflect these changes.

Improvements to HTML report generation:

* [`lib/src/commands/scan_command.dart`](diffhunk://#diff-48dee9b74902b99434936455455f2d34a72f2dfdf837512a6f6fb610ce47a268L173-R181): Modified the `generateHtmlReport` method to remove the call to `runOpenHtmlReport` and instead log a link to the generated HTML report.
* [`lib/src/system/system_runner.dart`](diffhunk://#diff-75704ec638b2cbabf06c0283cbdb023414665e73a05fd39e71df21ad13b341faL47-L62): Removed the `runOpenHtmlReport` method from the `SystemRunner` class as it is no longer needed.

Version updates:

* [`lib/src/version.dart`](diffhunk://#diff-389218715db21eae82edc77d255cd5fdcbab37f3a3d482b84aa82c75a9f9d52eL2-R2): Updated the `packageVersion` constant from '0.3.0' to '0.3.1'.
* [`pubspec.yaml`](diffhunk://#diff-8b7e9df87668ffa6a04b32e1769a33434999e54ae081c52e5d943c541d4c0d25L3-R3): Updated the version from '0.3.0' to '0.3.1'.

Testing adjustments:

* [`test/src/commands/scan_command_test.dart`](diffhunk://#diff-498622884b1c2039cf96645e73b6790e78dab8f25b8bb0b65395568e992a3266L227-L229): Removed calls and verifications related to `runOpenHtmlReport` in the tests to align with the new implementation. [[1]](diffhunk://#diff-498622884b1c2039cf96645e73b6790e78dab8f25b8bb0b65395568e992a3266L227-L229) [[2]](diffhunk://#diff-498622884b1c2039cf96645e73b6790e78dab8f25b8bb0b65395568e992a3266L273)