### PR TITLE
fix(14): delete old discover file before generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## Fix
 
 - Replace HTML report opening by logs with link
+- Delete old `discover-lcov.info` file before generating it
 
 # 0.3.0
 

--- a/lib/src/commands/scan_command.dart
+++ b/lib/src/commands/scan_command.dart
@@ -162,6 +162,9 @@ class ScanCommand extends Command<int> {
       'Generating lcov file for Dart files not listed in coverage file.',
     );
     final lcovFile = coverageDirectory.childFile('discover-lcov.info');
+    if (lcovFile.existsSync()) {
+      lcovFile.deleteSync();
+    }
     _lcovConverter.writeLcovFile(dartFilesNotInCoverage, lcovFile);
   }
 


### PR DESCRIPTION
This pull request includes a few changes to improve the handling of the `discover-lcov.info` file in the `scan_command.dart` file and the `CHANGELOG.md` documentation.

Changes to file handling:

* [`lib/src/commands/scan_command.dart`](diffhunk://#diff-48dee9b74902b99434936455455f2d34a72f2dfdf837512a6f6fb610ce47a268R165-R167): Added a check to delete the old `discover-lcov.info` file before generating a new one.

Documentation update:

* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8): Added a note to delete the old `discover-lcov.info` file before generating it.