### PR TITLE
fix(genhtml): fix html report gen command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+# 0.3.2
+
+## Fix
+
+- Fix "Failed to run genhtml"
+
 # 0.3.1
 
 ## Fix

--- a/lib/src/system/system_runner.dart
+++ b/lib/src/system/system_runner.dart
@@ -35,7 +35,8 @@ class SystemRunner {
       [
         '-o',
         'coverage/html',
-        'coverage/**lcov.info',
+        'coverage/lcov.info',
+        'coverage/discover-lcov.info',
       ],
       workingDirectory: projectPath,
     );

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '0.3.1';
+const packageVersion = '0.3.2';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: discover
 description: Discover your real coverage with Flutter including not tested Dart files.
-version: 0.3.1
+version: 0.3.2
 repository: https://github.com/PiotrFLEURY/discover
 
 environment:


### PR DESCRIPTION
This pull request includes updates to fix an issue with the `genhtml` command and updates the package version to 0.3.2. The most important changes are summarized below:

Fixes and improvements:

* [`lib/src/system/system_runner.dart`](diffhunk://#diff-75704ec638b2cbabf06c0283cbdb023414665e73a05fd39e71df21ad13b341faL38-R39): Modified the coverage file paths to include `coverage/discover-lcov.info` in addition to `coverage/lcov.info`.

Version updates:

* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR3-R8): Added a new entry for version 0.3.2, including a note about fixing the "Failed to run genhtml" issue.
* [`lib/src/version.dart`](diffhunk://#diff-389218715db21eae82edc77d255cd5fdcbab37f3a3d482b84aa82c75a9f9d52eL2-R2): Updated the package version constant to '0.3.2'.
* [`pubspec.yaml`](diffhunk://#diff-8b7e9df87668ffa6a04b32e1769a33434999e54ae081c52e5d943c541d4c0d25L3-R3): Updated the package version to 0.3.2.