### PR TITLE
fix(#26): lines with export-statement not ignored

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,19 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Dart: Run discover.dart",
+            "type": "dart",
+            "request": "launch",
+            "program": "bin/discover.dart",
+            "args": [
+                "scan",
+                "-p",
+                "flutter_example/"
+            ]
+        }
+    ]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Remove ignored files from original lcov.info tracefile
 
+## Fix
+
+- Fix [#26 lines with export-statement not ignored](https://github.com/PiotrFLEURY/discover/issues/26)
+
 # 0.3.2
 
 ## Fix

--- a/flutter_example/lib/model/models.dart
+++ b/flutter_example/lib/model/models.dart
@@ -1,0 +1,1 @@
+export 'car.dart';

--- a/flutter_example/lib/not_tested.dart
+++ b/flutter_example/lib/not_tested.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 
+export 'package:flutter/foundation.dart'; // Should be ignored
+
 class NotTested {
   void notTested() {
     debugPrint('This function is not tested');

--- a/lib/src/converters/dart_parser.dart
+++ b/lib/src/converters/dart_parser.dart
@@ -33,6 +33,7 @@ bool shouldIgnoreLine(String line) {
   return trimmedLine.isEmpty ||
       trimmedLine.startsWith('//') ||
       trimmedLine.startsWith('import') ||
+      trimmedLine.startsWith('export') ||
       trimmedLine.startsWith('part') ||
       trimmedLine.startsWith('class') ||
       trimmedLine.startsWith('mixin') ||

--- a/test/src/converters/dart_parser_test.dart
+++ b/test/src/converters/dart_parser_test.dart
@@ -67,5 +67,125 @@ Future<void> main() async {
         );
       }
     });
+    test('comments', () {
+      // GIVEN
+      const line = ' // This is a comment with a trailing space';
+
+      // WHEN
+      final shouldIgnore = parser.shouldIgnoreLine(line);
+
+      // THEN
+      expect(shouldIgnore, isTrue);
+    });
+    test('import', () {
+      // GIVEN
+      const line = "import 'package:flutter/material.dart';";
+
+      // WHEN
+      final shouldIgnore = parser.shouldIgnoreLine(line);
+
+      // THEN
+      expect(shouldIgnore, isTrue);
+    });
+    test('export', () {
+      // GIVEN
+      const line = "export 'package:flutter/foundation.dart';";
+
+      // WHEN
+      final shouldIgnore = parser.shouldIgnoreLine(line);
+
+      // THEN
+      expect(shouldIgnore, isTrue);
+    });
+    test('part', () {
+      // GIVEN
+      const line = "part 'car.g.dart';";
+
+      // WHEN
+      final shouldIgnore = parser.shouldIgnoreLine(line);
+
+      // THEN
+      expect(shouldIgnore, isTrue);
+    });
+    test('class', () {
+      // GIVEN
+      const line = 'class Car {';
+
+      // WHEN
+      final shouldIgnore = parser.shouldIgnoreLine(line);
+
+      // THEN
+      expect(shouldIgnore, isTrue);
+    });
+    test('mixin', () {
+      // GIVEN
+      const line = 'mixin Vehicle {';
+
+      // WHEN
+      final shouldIgnore = parser.shouldIgnoreLine(line);
+
+      // THEN
+      expect(shouldIgnore, isTrue);
+    });
+    test('extension', () {
+      // GIVEN
+      const line = 'extension Vehicle on Car {';
+
+      // WHEN
+      final shouldIgnore = parser.shouldIgnoreLine(line);
+
+      // THEN
+      expect(shouldIgnore, isTrue);
+    });
+    test('return', () {
+      // GIVEN
+      const line = 'return Car();';
+
+      // WHEN
+      final shouldIgnore = parser.shouldIgnoreLine(line);
+
+      // THEN
+      expect(shouldIgnore, isTrue);
+    });
+    test('closing curly brace', () {
+      // GIVEN
+      const line = '}';
+
+      // WHEN
+      final shouldIgnore = parser.shouldIgnoreLine(line);
+
+      // THEN
+      expect(shouldIgnore, isTrue);
+    });
+    test('closing parenthesis', () {
+      // GIVEN
+      const line = ');';
+
+      // WHEN
+      final shouldIgnore = parser.shouldIgnoreLine(line);
+
+      // THEN
+      expect(shouldIgnore, isTrue);
+    });
+    test('method', () {
+      // GIVEN
+      const line = 'void startEngine() {';
+
+      // WHEN
+      final shouldIgnore = parser.shouldIgnoreLine(line);
+
+      // THEN
+      expect(shouldIgnore, isTrue);
+    });
+    test('field', () {
+      // GIVEN
+      const line = 'final String brand;';
+
+      // WHEN
+      final shouldIgnore = parser.shouldIgnoreLine(line);
+
+      // THEN
+      expect(shouldIgnore, isFalse);
+    });
   });
 }


### PR DESCRIPTION
This pull request introduces several updates to improve the functionality of the Dart parser, enhance test coverage, and update project configurations. Key changes include adding support for ignoring `export` statements in the parser, updating the test suite to validate this behavior, and making minor project-level adjustments.

### Dart parser improvements:
* Updated `shouldIgnoreLine` in `lib/src/converters/dart_parser.dart` to ignore lines starting with `export`, ensuring consistency with other ignored statements like `import` and `part`.

### Test suite enhancements:
* Added comprehensive test cases in `test/src/converters/dart_parser_test.dart` to verify that various line types (e.g., `export`, `import`, `class`, `mixin`, etc.) are correctly identified as ignorable or non-ignorable by the parser.

### Project configuration updates:
* Added a new debug configuration in `.vscode/launch.json` for running the `discover.dart` script with specific arguments, streamlining development workflows.

### Documentation updates:
* Updated `CHANGELOG.md` to include a fix for issue #26, documenting the resolution of a bug related to unignored `export` statements.

### Minor code adjustments:
* Added `export` statements in `flutter_example/lib/model/models.dart` and `flutter_example/lib/not_tested.dart` for better modularity and organization. [[1]](diffhunk://#diff-e27b2013b2bdc1c7a5d6f682e683c2c0583d043fb4baa064944234be3aa1ae45R1) [[2]](diffhunk://#diff-e147a51b3a750af9235712d3862554667b1143d2e667165c9a69eca864178bfaR3-R4)