### PR TITLE
fix(25): HTML report not always generated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ## Fix
 
 - Fix [#26 lines with export-statement not ignored](https://github.com/PiotrFLEURY/discover/issues/26)
+- Fix [#25 HTML report not always generated](https://github.com/PiotrFLEURY/discover/issues/25)
 
 # 0.3.2
 

--- a/lib/src/system/system_runner.dart
+++ b/lib/src/system/system_runner.dart
@@ -36,15 +36,17 @@ class SystemRunner {
   /// Runs genhtml command to generate HTML report from LCOV file
   ///
   void runGenHTML(
-    String projectPath,
-  ) {
+    String projectPath, {
+    required bool discoverLcovExists,
+  }) {
     final process = Process.runSync(
       'genhtml',
       [
         '-o',
         'coverage/html',
         'coverage/lcov.info',
-        'coverage/discover-lcov.info',
+        if (discoverLcovExists) 'coverage/discover-lcov.info',
+        '--keep-descriptions',
       ],
       workingDirectory: projectPath,
     );

--- a/test/src/command_runner_test.dart
+++ b/test/src/command_runner_test.dart
@@ -177,6 +177,15 @@ void main() {
             .childFile('main.dart')
             .createSync(recursive: true);
 
+        when(() => systemRunner.runFlutterCoverage(any())).thenAnswer(
+          (_) async => memoryFileSystem.currentDirectory
+              .childDirectory('coverage')
+              .childFile('lcov.info')
+              .createSync(recursive: true),
+        );
+
+        when(() => logger.progress(any())).thenReturn(_MockProgress());
+
         // WHEN
         final result = await commandRunner.run([
           '--verbose',


### PR DESCRIPTION
This pull request introduces several fixes and enhancements to the `ScanCommand` class and its related components, primarily focusing on improving the handling of coverage files and ensuring the HTML report is always generated. Key changes include modifying the logic for generating coverage, adding support for conditional inclusion of `discover-lcov.info`, and updating related tests.

### Fixes
* Added a fix for issue #25, ensuring the HTML report is always generated. (`CHANGELOG.md`)

### Enhancements to Coverage Handling
* Updated `ScanCommand` to delete the `coverage` directory if it exists before regenerating coverage, ensuring a clean slate. (`lib/src/commands/scan_command.dart`)
* Modified `generateLcovFile` to return a boolean indicating whether `discover-lcov.info` was generated, enabling conditional logic for subsequent steps. (`lib/src/commands/scan_command.dart`) [[1]](diffhunk://#diff-48dee9b74902b99434936455455f2d34a72f2dfdf837512a6f6fb610ce47a268L163-R171) [[2]](diffhunk://#diff-48dee9b74902b99434936455455f2d34a72f2dfdf837512a6f6fb610ce47a268R182-R193)

### HTML Report Generation Improvements
* Updated `generateHtmlReport` to accept a `discoverLcovExists` parameter, allowing conditional inclusion of `discover-lcov.info` in the `genhtml` command. (`lib/src/commands/scan_command.dart`, `lib/src/system/system_runner.dart`) [[1]](diffhunk://#diff-48dee9b74902b99434936455455f2d34a72f2dfdf837512a6f6fb610ce47a268L199-R222) [[2]](diffhunk://#diff-75704ec638b2cbabf06c0283cbdb023414665e73a05fd39e71df21ad13b341faL39-R49)

### Test Updates
* Added new tests to verify that the HTML report is always generated and that `discover-lcov.info` is conditionally included based on its existence. (`test/src/commands/scan_command_test.dart`) [[1]](diffhunk://#diff-498622884b1c2039cf96645e73b6790e78dab8f25b8bb0b65395568e992a3266L225-R266) [[2]](diffhunk://#diff-498622884b1c2039cf96645e73b6790e78dab8f25b8bb0b65395568e992a3266L269-R315)